### PR TITLE
chore: update repository template to 6989295f

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+# github:
+patreon: _ory
+open_collective: ory

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+<!--
+1. Call function `foo.Bar`
+2. Function returns invalid value `baz`
+-->
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Environment**
+
+- Version: v1.2.3, git sha hash
+- Environment: Debian, Docker, ...
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ory Ory Hydra Go Client Forum
+    url: https://github.com/ory/hydra-client-go/discussions
+    about: Please ask and answer questions here, show your implementations and discuss ideas.
+  - name: Ory Chat
+    url: https://www.ory.sh/chat
+    about: Hang out with other Ory community members to ask and answer questions.
+  - name: Ory Support for Business
+    url: https://github.com/ory/open-source-support/blob/master/README.md
+    about: Buy professional support for Ory Ory Hydra Go Client.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've
+considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,15 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+assignees:
+  - ory/maintainers
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+addAssignees: author

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,3 @@
+todo:
+  keyword: "@todo"
+  label: todo

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+
+This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
+If your change includes breaking changes please add a codeblock documenting the breaking change:
+
+```
+BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
+behavior please do baz.
+```
+-->
+
+## Related issue(s)
+
+<!--
+Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
+with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).
+
+If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
+chance substantial changes will be requested or that the changes will be rejected.
+
+You can discuss changes with maintainers either in the Github Discusssions in this repository or
+join the [Ory Chat](https://www.ory.sh/chat).
+-->
+
+## Checklist
+
+<!--
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
+them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
+-->
+
+- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
+      and signed the CLA.
+- [ ] I have read the [security policy](../security/policy).
+- [ ] I confirm that this pull request does not address a security
+      vulnerability. If this pull request addresses a security vulnerability, I
+      confirm that I got green light (please contact
+      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
+      the changes.
+- [ ] I have added tests that prove my fix is effective or that my feature
+      works.
+- [ ] I have added necessary documentation within the code base (if
+      appropriate).
+
+## Further comments
+
+<!--
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
+you did and what alternatives you considered, etc...
+-->

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,17 @@
+titleOnly: true
+commitsOnly: false
+titleAndCommits: false
+
+types:
+  - feat
+  - fix
+  - revert
+  - docs
+  - style
+  - refactor
+  - test
+  - build
+  - autogen
+  - security
+  - ci
+  - chore

--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -1,0 +1,27 @@
+name: Closed Reference Notifier
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      issueLimit:
+        description: Max. number of issues to create
+        required: true
+        default: '5'
+
+jobs:
+  find_closed_references:
+    if: github.repository_owner == 'ory'
+    runs-on: ubuntu-latest
+    name: Find closed references
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - uses: ory/closed-reference-notifier@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issueLabels: upstream,good first issue,help wanted
+          issueLimit: ${{ github.event.inputs.issueLimit || '5' }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,22 @@
+name: Synchronize Issue Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  milestone:
+    if: github.repository_owner == 'ory'
+    name: Synchronize Issue Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Synchronize Issue Labels
+        uses: ory/label-sync-action@v0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dry: false
+          forced: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: "Close Stale Issues"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    if: github.repository_owner == 'ory'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            Hello contributors!
+
+            I am marking this issue as stale as it has not received any engagement from the community or maintainers a year. That does not imply that the issue has no merit! If you feel strongly about this issue
+
+            - open a PR referencing and resolving the issue;
+            - leave a comment on it and discuss ideas how you could contribute towards resolving it;
+            - leave a comment and describe in detail why this issue is critical for your use case;
+            - open a new issue with updated details and a plan on resolving the issue.
+
+            Throughout its lifetime, Ory has received over 10.000 issues and PRs. To sustain that growth, we need to prioritize and focus on issues that are important to the community. A good indication of importance, and thus priority, is activity on a topic.
+
+            Unfortunately, [burnout](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) has become a [topic](https://opensource.guide/best-practices/#its-okay-to-hit-pause) of [concern](https://docs.brew.sh/Maintainers-Avoiding-Burnout) amongst open-source projects.
+
+            It can lead to severe personal and health issues as well as [opening](https://haacked.com/archive/2019/05/28/maintainer-burnout/) catastrophic [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+
+            The motivation for this automation is to help prioritize issues in the backlog and not ignore, reject, or belittle anyone.
+
+            If this issue was marked as stale erroneous you can exempt it by adding the `backlog` label, assigning someone, or setting a milestone for it.
+
+            Thank you for your understanding and to anyone who participated in the conversation! And as written above, please do participate in the conversation if this topic is important to you!
+
+            Thank you 🙏✌️
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'bug,blocking,docs,backlog'
+          days-before-stale: 365
+          days-before-close: 30
+          exempt-milestones: true
+          exempt-assignees: true
+          only-pr-labels: 'stale'

--- a/.reference-ignore
+++ b/.reference-ignore
@@ -1,0 +1,3 @@
+**/node_modules
+docs
+CHANGELOG.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at office@ory.sh. All complaints will be
+reviewed and investigated and will result in a response that is deemed necessary
+and appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,265 @@
+<!--
+
+Thank you for contributing changes to this document! Because we use a central repository
+to synchronize this file across all our repositories, make sure to make your edits
+in the correct file, which you can find here:
+
+https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING.md
+
+-->
+
+# Contributing to Ory Ory Hydra Go Client
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [FAQ](#faq)
+- [How can I contribute?](#how-can-i-contribute)
+- [Communication](#communication)
+- [Contributing Code](#contributing-code)
+- [Documentation](#documentation)
+- [Disclosing vulnerabilities](#disclosing-vulnerabilities)
+- [Code Style](#code-style)
+  - [Working with Forks](#working-with-forks)
+- [Conduct](#conduct)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+There are many ways in which you can contribute, beyond writing code. The goal
+of this document is to provide a high-level overview of how you can get
+involved.
+
+_Please note_: We take Ory Ory Hydra Go Client's security and our users' trust very
+seriously. If you believe you have found a security issue in Ory Ory Hydra Go Client,
+please responsibly disclose by contacting us at security@ory.sh.
+
+First: As a potential contributor, your changes and ideas are welcome at any
+hour of the day or night, weekdays, weekends, and holidays. Please do not ever
+hesitate to ask a question or send a pull request.
+
+If you are unsure, just ask or submit the issue or pull request anyways. You
+won't be yelled at for giving it your best effort. The worst that can happen is
+that you'll be politely asked to change something. We appreciate any sort of
+contributions, and don't want a wall of rules to get in the way of that.
+
+That said, if you want to ensure that a pull request is likely to be merged,
+talk to us! You can find out our thoughts and ensure that your contribution
+won't clash or be obviated by Ory
+Ory Hydra Go Client's normal direction. A great way to
+do this is via
+[Ory Ory Hydra Go Client Discussions](https://github.com/ory/meta/discussions)
+or the [Ory Chat](https://www.ory.sh/chat).
+
+## FAQ
+
+- I am new to the community. Where can I find the
+  [Ory Community Code of Conduct?](https://github.com/ory/hydra-client-go/blob/master/CODE_OF_CONDUCT.md)
+
+- I have a question. Where can I get
+  [answers to questions regarding Ory Ory Hydra Go Client?](#communication)
+
+- I would like to contribute but I am not sure how. Are there
+  [easy ways to contribute?](#how-can-i-contribute)
+  [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
+
+- I want to talk to other Ory Ory Hydra Go Client users.
+  [How can I become a part of the community?](#communication)
+
+- I would like to know what I am agreeing to when I contribute to Ory
+  Ory Hydra Go Client.
+  Does Ory have
+  [a Contributors License Agreement?](https://cla-assistant.io/ory/hydra-client-go)
+
+- I would like updates about new versions of Ory Ory Hydra Go Client.
+  [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
+
+## How can I contribute?
+
+If you want to start contributing code right away, we have a
+[list of good first issues](https://github.com/ory/hydra-client-go/labels/good%20first%20issue).
+
+There are many other ways you can contribute without writing any code. Here are
+a few things you can do to help out:
+
+- **Give us a star.** It may not seem like much, but it really makes a
+  difference. This is something that everyone can do to help out Ory Ory Hydra Go Client.
+  Github stars help the project gain visibility and stand out.
+
+- **Join the community.** Sometimes helping people can be as easy as listening
+  to their problems and offering a different perspective. Join our Slack, have a
+  look at discussions in the forum and take part in our weekly hangout. More
+  info on this in [Communication](#communication).
+
+- **Helping with open issues.** We have a lot of open issues for Ory Ory Hydra Go Client
+  and some of them may lack necessary information, some are duplicates of older
+  issues. You can help out by guiding people through the process of filling out
+  the issue template, asking for clarifying information, or pointing them to
+  existing issues that match their description of the problem.
+
+- **Reviewing documentation changes.** Most documentation just needs a review
+  for proper spelling and grammar. If you think a document can be improved in
+  any way, feel free to hit the `edit` button at the top of the page. More info
+  on contributing to documentation [here](#documentation).
+
+- **Help with tests.** Some pull requests may lack proper tests or test plans.
+  These are needed for the change to be implemented safely.
+
+## Communication
+
+We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
+questions, discuss bugs and feature requests, talk to other users of Ory, etc.
+
+Check out [Ory Ory Hydra Go Client Discussions](https://github.com/ory/meta/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
+
+You can also join our community hangout, if you want to speak to the Ory team
+directly or ask some questions. You can find more info on the hangouts in
+[Slack](https://www.ory.sh/chat).
+
+If you want to receive regular notifications about updates to Ory Ory Hydra Go Client,
+consider joining the mailing list. We will _only_ send you vital information on
+the projects that you are interested in.
+
+Also [follow us on twitter](https://twitter.com/orycorp).
+
+## Contributing Code
+
+Unless you are fixing a known bug, we **strongly** recommend discussing it with
+the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
+before getting started to ensure your work is consistent with Ory Ory Hydra Go Client's
+roadmap and architecture.
+
+All contributions are made via pull requests. To make a pull request, you will
+need a GitHub account; if you are unclear on this process, see GitHub's
+documentation on [forking](https://help.github.com/articles/fork-a-repo) and
+[pull requests](https://help.github.com/articles/using-pull-requests). Pull
+requests should be targeted at the `master` branch. Before creating a pull
+request, go through this checklist:
+
+1. Create a feature branch off of `master` so that changes do not get mixed up.
+1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local
+   changes against the `master` branch.
+1. Run the full project test suite with the `go test -tags sqlite ./...` (or
+   equivalent) command and confirm that it passes.
+1. Run `make format` if a `Makefile` is available, `gofmt -s` if the project is
+   written in Go, `npm run format` if the project is written for NodeJS.
+1. Ensure that each commit has a descriptive prefix. This ensures a uniform
+   commit history and helps structure the changelog.  
+   Please refer to this
+   [list of prefixes for Ory Hydra Go Client](https://github.com/ory/hydra-client-go/blob/master/.github/semantic.yml)
+   for an overview.
+1. Sign-up with CircleCI so that it has access to your repository with the
+   branch containing your PR. Simply creating a CircleCI account is sufficient
+   for the CI jobs to run, you do not need to setup a CircleCI project for the
+   branch.
+
+If a pull request is not ready to be reviewed yet
+[it should be marked as a "Draft"](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
+
+Before your contributions can be reviewed you need to sign our
+[Contributor License Agreement](https://cla-assistant.io/ory/hydra-client-go).
+
+This agreement defines the terms under which your code is contributed to Ory.
+More specifically it declares that you have the right to, and actually do, grant
+us the rights to use your contribution. You can see the Apache 2.0 license under
+which our projects are published
+[here](https://github.com/ory/meta/blob/master/LICENSE).
+
+When pull requests fail testing, authors are expected to update their pull
+requests to address the failures until the tests pass.
+
+Pull requests eligible for review
+
+1. follow the repository's code formatting conventions;
+2. include tests which prove that the change works as intended and does not add
+   regressions;
+3. document the changes in the code and/or the project's documentation;
+4. pass the CI pipeline;
+5. have signed our
+   [Contributor License Agreement](https://cla-assistant.io/ory/hydra-client-go);
+6. include a proper git commit message following the
+   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+If all of these items are checked, the pull request is ready to be reviewed and
+you should change the status to "Ready for review" and
+[request review from a maintainer](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
+
+Reviewers will approve the pull request once they are satisfied with the patch.
+
+## Documentation
+
+Please provide documentation when changing, removing, or adding features.
+Documentation resides in the project's
+[docs](https://github.com/ory/hydra-client-go/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
+
+For further instructions please head over to
+[docs/README.md](https://github.com/ory/hydra-client-go/blob/master/README.md).
+
+## Disclosing vulnerabilities
+
+Please disclose vulnerabilities exclusively to
+[security@ory.sh](mailto:security@ory.sh). Do not use GitHub issues.
+
+## Code Style
+
+Please follow these guidelines when formatting source code:
+
+- Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
+- NodeJS and JavaScript code should be prettified using `npm run format` where
+  appropriate.
+
+### Working with Forks
+
+```
+# First you clone the original repository
+git clone git@github.com:ory/ory/hydra-client-go.git
+
+# Next you add a git remote that is your fork:
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/hydra-client-go.git
+
+# Next you fetch the latest changes from origin for master:
+git fetch origin
+git checkout master
+git pull --rebase
+
+# Next you create a new feature branch off of master:
+git checkout my-feature-branch
+
+# Now you do your work and commit your changes:
+git add -A
+git commit -a -m "fix: this is the subject line" -m "This is the body line. Closes #123"
+
+# And the last step is pushing this to your fork
+git push -u fork my-feature-branch
+```
+
+Now go to the project's GitHub Pull Request page and click "New pull request"
+
+## Conduct
+
+Whether you are a regular contributor or a newcomer, we care about making this
+community a safe place for you and we've got your back.
+
+- We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of gender, sexual orientation, disability, ethnicity,
+  religion, or similar personal characteristic.
+- Please avoid using nicknames that might detract from a friendly, safe and
+  welcoming environment for all.
+- Be kind and courteous. There is no need to be mean or rude.
+- We will exclude you from interaction if you insult, demean or harass anyone.
+  In particular, we do not tolerate behavior that excludes people in socially
+  marginalized groups.
+- Private harassment is also unacceptable. No matter who you are, if you feel
+  you have been or are being harassed or made uncomfortable by a community
+  member, please contact one of the channel ops or a member of the Ory Ory Hydra Go Client
+  core team immediately.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behaviour is not welcome.
+
+We welcome discussion about creating a welcoming, safe, and productive
+environment for the community. If you have any questions, feedback, or concerns
+[please let us know](https://www.ory.sh/chat).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+<!--
+
+Thank you for contributing changes to this document! Because we use a central repository
+to synchronize this file across all our repositories, make sure to make your edits
+in the correct file, which you can find here:
+
+https://github.com/ory/meta/blob/master/templates/repository/SECURITY.md
+
+-->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Security Policy](#security-policy)
+  - [Supported Versions](#supported-versions)
+  - [Reporting a Vulnerability](#reporting-a-vulnerability)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Security Policy
+
+## Supported Versions
+
+We release patches for security vulnerabilities. Which versions are eligible
+receiving such patches depend on the CVSS v3.0 Rating:
+
+| CVSS v3.0 | Supported Versions                        |
+| --------- | ----------------------------------------- |
+| 9.0-10.0  | Releases within the previous three months |
+| 4.0-8.9   | Most recent release                       |
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to
+**[security@ory.sh](mailto:security@ory.sh)**. You will receive a response from
+us within 48 hours. If the issue is confirmed, we will release a patch as soon
+as possible depending on complexity but historically within a few days.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/6989295f43aa448ef3131766fd13eaaac2905f1d.